### PR TITLE
Add Llaravel 12 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "homepage": "https://github.com/spindogs/laravel-spin-forms",
     "keywords": ["Laravel", "LaravelSpinForms"],
     "require": {
-        "illuminate/support": "~11"
+        "illuminate/support": "~11|~12"
     },
     "require-dev": {
         "phpunit/phpunit": "~11"

--- a/readme.md
+++ b/readme.md
@@ -398,3 +398,4 @@ Versions will be supported for a limited amount of time.
 | 2 | 7/8/9 |
 | 3 | 10 |
 | 4 | 11 |
+| 5 | 11/12 |


### PR DESCRIPTION
This PR adds Laravel 12 support to the package by updating the version constraints on the `illuminate/support` package to include the version used by Laravel 12. This PR also updates the version table listed in the README.